### PR TITLE
V.1.2

### DIFF
--- a/Get-FolderAge.Tests.ps1
+++ b/Get-FolderAge.Tests.ps1
@@ -157,6 +157,17 @@ Describe "Proper $CommandName Functionality" {
         $Result0.TotalFiles -eq $Result1.TotalFiles | Should -Be $true
     }
 
+    It 'Runs Threads with the same output file' {
+        $File1 = Join-Path 'TestFolder' 'NoThreads.csv'
+        $File2 = Join-Path 'TestFolder' 'WithThreads.csv'
+        $Result0 = Get-FolderAge -FolderName 'TestFolder' -TestSubFolders -OutputFile $File1
+        $Result1 = Get-FolderAge -FolderName 'TestFolder' -TestSubFolders -OutputFile $File2 -Threads 2 -ea 0
+        $Count1 = (Get-Content $File1).Count
+        $Count2 = (Get-Content $File2).Count
+        $Count2 | Should -Be $Count1 -Because "NoThreads and WithThreads should be the same"
+        $Count2 | Should -Be ($Result1.Count + 1) -Because "Pipeline and File should differ by 1 (header line)"
+    }
+
 }
 
 Describe "V2 Compatibility check for $CommandName" {

--- a/Get-FolderAge.Tests.ps1
+++ b/Get-FolderAge.Tests.ps1
@@ -38,6 +38,11 @@ Describe "Function $CommandName Definition" {
             $CmdDef.Parameters.Keys | Should -Contain $P1
         }
     }
+
+    It 'Command should have alias' {
+        Get-Alias -Definition $CommandName -ea 0 | Should -Not -Be $null
+    }
+
 }
 
 

--- a/Get-FolderAge.md
+++ b/Get-FolderAge.md
@@ -105,10 +105,11 @@ Accept wildcard characters: False
 ```
 
 ### -OutputFile
-A string specifying file name which will be used for output.
-If not specified, there will be no file output generated.
-This is especially useful for long running commands.
-Each folder as soon as processed will be stored in the file.
+A string specifying file name which will be used for output in addition to screen (or pipeline) output.
+This is especially useful for long running commands. Each folder as soon as processed will be stored in the file.
+This can be also used for restarting the script, if it gets interrupted before it finishes all folders.
+Just specify the same input and output files, and script will skip already processed folders!
+If this parameter is not specified, there will be no file output generated.
 
 ```yaml
 Type: String

--- a/Get-FolderAge.ps1
+++ b/Get-FolderAge.ps1
@@ -12,7 +12,7 @@
 .EXTERNALMODULEDEPENDENCIES 
 .REQUIREDSCRIPTS 
 .EXTERNALSCRIPTDEPENDENCIES 
-.RELEASENOTES Bug fixes for append and threads issues, added restartable functionality and alias, for more info see https://github.com/iricigor/GetFolderAge/blob/master/ReleaseNotes.md
+.RELEASENOTES Added restartable script functionality and alias, bug fixes for append and threads issues, for more info see https://github.com/iricigor/GetFolderAge/blob/master/ReleaseNotes.md
 .DESCRIPTION Get-FolderAge returns `LastModifiedDate` for a specified folder(s) and if folders were modified after a specified cut-off date.
 
 #>
@@ -103,8 +103,11 @@ function Global:Get-FolderAge {
     If both CutOffTime and CutOffDays specified, the script will throw a warning.
     
     .PARAMETER OutputFile
-    A string specifying file name which will be used for output. If not specified, there will be no file output generated.
+    A string specifying file name which will be used for output in addition to screen (or pipeline) output.
     This is especially useful for long running commands. Each folder as soon as processed will be stored in the file.
+    This can be also used for restarting the script, if it gets interrupted before it finishes all folders.
+    Just specify the same input and output files, and script will skip already processed folders!
+    If this parameter is not specified, there will be no file output generated.
     
     .PARAMETER Exclude
     Specifies, as a string array, an folder names that this cmdlet excludes in the search operation.

--- a/Get-FolderAge.ps1
+++ b/Get-FolderAge.ps1
@@ -441,4 +441,4 @@ function Global:Get-FolderAge {
 }
 
 
-New-Alias -Name gfa -Value Get-FolderAge
+Set-Alias -Name gfa -Value Get-FolderAge

--- a/Get-FolderAge.ps1
+++ b/Get-FolderAge.ps1
@@ -166,7 +166,8 @@ function Global:Get-FolderAge {
 
         [parameter(Mandatory=$false)] [string[]]$Exclude,
 
-        [parameter(Mandatory=$false)] [int]$Threads = 0,
+        [parameter(Mandatory=$false)]
+        [ValidateRange(0,50)]         [int]$Threads = 0,
 
         #
         # Switches
@@ -471,7 +472,8 @@ function Global:Get-FolderAge {
         # if threads, receive them
         if ($Threads -gt 1) {
             Write-Verbose -Message "$(Get-Date -f T) $FunctionName waiting for background jobs results."
-            Receive-Job $JobList -Wait            
+            Receive-Job $JobList -Wait
+            Remove-Job $JobList
         }
 
         # function closing phase

--- a/Get-FolderAge.ps1
+++ b/Get-FolderAge.ps1
@@ -1,6 +1,6 @@
 <#PSScriptInfo
 
-.VERSION 1.1
+.VERSION 1.2
 .GUID c9788cc2-d4af-4219-bf7d-8dd8fa89584f
 .AUTHOR Igor Iric, iricigor@gmail.com, https://github.com/iricigor
 .COMPANYNAME 
@@ -12,7 +12,7 @@
 .EXTERNALMODULEDEPENDENCIES 
 .REQUIREDSCRIPTS 
 .EXTERNALSCRIPTDEPENDENCIES 
-.RELEASENOTES Added -Exclude and -Threads parameters, for more info see https://github.com/iricigor/GetFolderAge/blob/master/ReleaseNotes.md
+.RELEASENOTES Bug fixes for append and threads issues, added restartable functionality and alias, for more info see https://github.com/iricigor/GetFolderAge/blob/master/ReleaseNotes.md
 .DESCRIPTION Get-FolderAge returns `LastModifiedDate` for a specified folder(s) and if folders were modified after a specified cut-off date.
 
 #>
@@ -439,3 +439,6 @@ function Global:Get-FolderAge {
     }
     
 }
+
+
+New-Alias -Name gfa -Value Get-FolderAge

--- a/Get-FolderAge.ps1
+++ b/Get-FolderAge.ps1
@@ -412,7 +412,7 @@ function Global:Get-FolderAge {
                         }
                     } else {
                         try {
-                            $RetVal | ConvertTo-Csv -NoTypeInformation | Select -Skip 1 | Out-File -Path $OutputFile -Append -Encoding Unicode
+                            $RetVal | ConvertTo-Csv -NoTypeInformation | Select -Skip 1 | Out-File -FilePath $OutputFile -Append -Encoding Unicode
                             Write-Verbose -Message "$(Get-Date -f T)   appended new line to output file $OutputFile"
                         } catch {
                             Write-Error "$FunctionName failed to append date to $OutputFile, entry for $Folder will be skipped.`n$_"

--- a/Get-FolderAge.ps1
+++ b/Get-FolderAge.ps1
@@ -185,10 +185,10 @@ function Global:Get-FolderAge {
 
         # process $InputFile
         if ($InputFile) {
-            if (!(Test-Path $InputFile)) {
+            if (!(Test-Path -LiteralPath $InputFile)) {
                 throw "$FunctionName cannot find input file $InputFile"
             }
-            $FolderName = Get-Content -Path $InputFile -ErrorAction SilentlyContinue
+            $FolderName = Get-Content -LiteralPath $InputFile -ErrorAction SilentlyContinue
             if ($FolderName) {
                 Write-Verbose -Message "$(Get-Date -f T)   successfully read $InputFile with $(@($FolderName).Count) entries"
             } else {
@@ -253,7 +253,7 @@ function Global:Get-FolderAge {
                 Write-Error "$FunctionName cannot find folder $FolderEntry"
                 continue
             }
-            $RP = Resolve-Path $FolderEntry
+            $RP = Resolve-Path -LiteralPath $FolderEntry
             if ($RP.Provider.Name -ne 'FileSystem') {
                 Write-Error "$FunctionName provided path $FolderEntry is not on the FileSystem"
                 continue
@@ -263,7 +263,7 @@ function Global:Get-FolderAge {
             }
 
             if ($TestSubFolders) {
-                $FolderList = @(Get-ChildItem $FolderEntry -Directory -ea SilentlyContinue | Select -Expand FullName)
+                $FolderList = @(Get-ChildItem -LiteralPath $FolderEntry -Directory -ea SilentlyContinue | Select -Expand FullName)
                 if ($FolderList) {
                     Write-Verbose -Message "$(Get-Date -f T)   Processing $($FolderList.Count) subfolders of $FolderEntry"
                 } else {
@@ -286,7 +286,6 @@ function Global:Get-FolderAge {
                     if ($CutOffTime) {$JobCode += " -CutOffTime '$CutOffString'"}
                     if ($Exclude) {$Join = "', '"; $JobCode += " -Exclude '$($Exclude -join $Join)'"}
                     if ($OutputFile) {$JobCode += " -OutputFile '$OutputFile'"}
-                    # TODO: Process other required parameters: CutOffTime, Exclude, OutputFile
                     Write-Verbose -Message "$(Get-Date -f T)   starting background job for '$Folder': $JobCode"
                     $JobCode = ". $SourceFile`n$JobCode" # first import function 
                     $JobList += Start-ThreadJob -ScriptBlock ([Scriptblock]::Create($JobCode)) -ThrottleLimit $Threads
@@ -298,7 +297,7 @@ function Global:Get-FolderAge {
                 $StartTime = Get-Date
                 $i = 0
                 $queue = @($Folder)
-                $LastWriteTime = Get-Item -Path $Folder | Select -Expand LastWriteTime
+                $LastWriteTime = Get-Item -LiteralPath $Folder | Select -Expand LastWriteTime
                 $TotalFiles = 0
                 $LastItemName = $Folder
                 $KeepProcessing = $true
@@ -413,7 +412,7 @@ function Global:Get-FolderAge {
                         }
                     } else {
                         try {
-                            $RetVal | ConvertTo-Csv -NoTypeInformation | Select -Skip 1 | Out-File -LiteralPath $OutputFile -Append -Encoding Unicode
+                            $RetVal | ConvertTo-Csv -NoTypeInformation | Select -Skip 1 | Out-File -Path $OutputFile -Append -Encoding Unicode
                             Write-Verbose -Message "$(Get-Date -f T)   appended new line to output file $OutputFile"
                         } catch {
                             Write-Error "$FunctionName failed to append date to $OutputFile, entry for $Folder will be skipped.`n$_"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # GetFolderAge
 
 Latest version:
-![GitHub release](https://img.shields.io/github/release/iricigor/GetFolderAge.svg)
+![GitHub Latest Release](https://img.shields.io/github/release/iricigor/GetFolderAge.svg)
 ![GitHub Release Date](https://img.shields.io/github/release-date/iricigor/GetFolderAge.svg)
+![GitHub repo size in bytes](https://img.shields.io/github/repo-size/iricigor/GetFolderAge.svg)
 
 PowerShell script which checks for last modified date _(LastWriteTime)_ for large number of folders.
 It checks recursively for all files and folders inside taking into account potential errors (inaccessible files, too long paths, etc.).
@@ -27,7 +28,7 @@ You can see online latest script version at this [link](https://github.com/irici
 Raw PS1 file can be downloaded from [here](https://raw.githubusercontent.com/iricigor/GetFolderAge/master/Get-FolderAge.ps1).
 
 - **Clone repository:**
-If you want to see entire GitHub repository, just clone it 
+If you want to see entire GitHub repository, just clone it
 
 `git clone https://github.com/iricigor/GetFolderAge.git`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Latest version:
 ![GitHub Release Date](https://img.shields.io/github/release-date/iricigor/GetFolderAge.svg)
 ![GitHub repo size in bytes](https://img.shields.io/github/repo-size/iricigor/GetFolderAge.svg)
 
-PowerShell script which checks for last modified date _(LastWriteTime)_ for large number of folders.
+PowerShell script which checks for last modified date _(LastWriteTime)_ for a large number of folders.
 It checks recursively for all files and folders inside taking into account potential errors (inaccessible files, too long paths, etc.).
 
 Running a script itself will just import (i.e. create) new commandlet **`Get-FolderAge`** in your session.
@@ -13,27 +13,27 @@ It will not do any checks.
 You can afterwards run this commandlet with proper parameters as in examples below.
 
 Running commandlet with specifying only a folder name will return last modification time of that folder.
-If you specify `-CutOffDate` (or `-CutoffDays`) script will determine if folder was modified after that time. It will exit folder search as soon as it finds modified file or folder.
+If you specify `-CutOffDate` (or `-CutoffDays`) script will determine if the folder was modified after that time. It will exit folder search as soon as it finds a modified file or folder.
 
-Commandlet can be run in un-attended mode also with file output using `-OutputFileName` parameter. Output format is comma-separated value, so file extension should be `.csv`.
+Commandlet can be run in unattended mode also with file output using `-OutputFileName` parameter. Output format is comma-separated value, so file extension should be `.csv`.
 
 Technical explanation of LastModifiedDate can be seen in [this archived copy](https://web.archive.org/web/20110604022236/http://support.microsoft.com/kb/299648) of Microsoft knowledge base article.
 
 ## Download
 
-You can download this script in couple of ways listed below. Execute a script after downloading it (no admin rights needed) to add commandlet `Get-FolderAge` to your session.
+You can download this script in a couple of ways listed below. Execute a script after downloading it (no admin rights needed) to add commandlet `Get-FolderAge` to your session.
 
 - **Download from GitHub:**
 You can see online latest script version at this [link](https://github.com/iricigor/GetFolderAge/blob/master/Get-FolderAge.ps1).
-Raw PS1 file can be downloaded from [here](https://raw.githubusercontent.com/iricigor/GetFolderAge/master/Get-FolderAge.ps1).
+The raw PS1 file can be downloaded from [here](https://raw.githubusercontent.com/iricigor/GetFolderAge/master/Get-FolderAge.ps1).
 
 - **Clone repository:**
-If you want to see entire GitHub repository, just clone it
+If you want to see the entire GitHub repository, just clone it
 
 `git clone https://github.com/iricigor/GetFolderAge.git`
 
 - **From PowerShell Gallery** _(preferred way)_:
-Script can be downloaded from [PS Gallery](https://www.powershellgallery.com/packages/Get-FolderAge) using command 
+Script can be downloaded from [PS Gallery](https://www.powershellgallery.com/packages/Get-FolderAge) using the command 
 
 `Save-Script Get-FolderAge -Repository PSGallery -Path 'MyFolder'`
 
@@ -53,7 +53,7 @@ Returns last modification date of the specified folder.
 
 * `Get-FolderAge -Folder '\\FileServer01.Contoso.com\Users' -TestSubFolders`
 
-Returns last modification date for each user share on file server.
+Returns last modification date for each user share on a file server.
 
 * `Get-FolderAge -InputFile 'ShareList.txt' -OutputFile 'ShareScanResults.csv' -CutoffDays 3`
 
@@ -64,7 +64,7 @@ Tests if folders listed in specified input file (one folder per line) are modifi
 Input can be specified in three ways:
 
 * parameter `-FolderName` _(default parameter, can be omitted)_ followed by string or an array of strings specifying paths to be checked
-* via pipeline - the same values as above can be passed via pipeline, see example with `Get-ChildItem`
+* via pipeline - the same values as above can be passed via pipeline, see the example with `Get-ChildItem`
 * parameter `-InputFile` - a file specifying folders to be processed, one folder per line
 
 ![Screenshot 2](img/Screenshot_2.png)
@@ -72,27 +72,27 @@ Input can be specified in three ways:
 ### Cut-off Date explanation
 
 Cut-off date represents the point in time for which we want to know if a folder was modified after.
-Usually this is the date when last copy or backup or sync was performed on given folder.
+Usually, this is the date when last copy or backup or sync was performed on the given folder.
 
 It can be specified as:
 
 * PowerShell [DateTime] object, i.e. the value returned by Get-Date command
-* Integer number representing days since last cut-off date (easier, but less precise)
+* An integer number representing days since last cut-off date (easier, but less precise)
 
 ### Output format
 
-Commandlet outputs array of FolderAgeResult objects. Each object contain these properties:
+Commandlet outputs array of objects. Each object contains these properties:
 
 * [string]`Path` - as specified in input parameters (or obtained subfolder names)
 * [datetime]`LastWriteTime` - latest write time for all items inside of the folder
-* [bool]`Modified` - if folder was modified since last cut-off date (or null if date not given)
+* [bool]`Modified` - if the folder was modified since last cut-off date (or null if date not given)
 
 It also outputs diagnostic/statistics info:
 
-* [bool]`Confident` - if Modified return value is confident result, in case commandlet is called with QuickTest switch, return value for Modified might not be correct.
+* [bool]`Confident` - if Modified return value is a confident result; in case commandlet is called with QuickTest switch, return value for Modified might not be correct.
 * [int]`TotalFiles` - total number of files and directories scanned
 * [int]`TotalFolders` - total number of directories scanned
-* [string]`LastItem` - item with latest timestamp found (note that this might not ber really the latest modified file. If this timestamp is newer than CutOffDate, commandlet will not search further.
+* [string]`LastItem` - an item with the latest timestamp found (note that this might not be really the latest modified file. If this timestamp is newer than CutOffDate, commandlet will not search further.
 * [int]`Depth` - total depth of scanned folders relative to initial folder. If QuickTest, then it will be 1, regardless of real depth. If CutOffDate specified, it might not go to full depth, so this number will be smaller than full depth.
 * [decimal]`ElapsedSeconds` - time spent in checking the folder
 * [datetime]`FinishTime` - date and time when folder check was completed
@@ -102,10 +102,10 @@ It also outputs diagnostic/statistics info:
 ### Restartable script
 
 Parameter `-OutputFile` specifies where output data is stored on the disk.
-If script is interrupted before finishing, you can restart it without a need to process same folders again.
-Just specify the same `-OutputFile` and script will skip already processed folders.
+If the script is interrupted before finishing, you can restart it without a need to process same folders again.
+Just specify the same `-OutputFile` and `-InputFile` and script will skip already processed folders!
 
-This is specially useful for long running scripts.
+This is especially useful for long running scripts.
 
 ## Build status
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,16 @@ It also outputs diagnostic/statistics info:
 * [int]`Depth` - total depth of scanned folders relative to initial folder. If QuickTest, then it will be 1, regardless of real depth. If CutOffDate specified, it might not go to full depth, so this number will be smaller than full depth.
 * [decimal]`ElapsedSeconds` - time spent in checking the folder
 * [datetime]`FinishTime` - date and time when folder check was completed
-* [bool]`Errors` - indicate if command encountered errors during its execution (i.e. Access Denied on part of the files)
+* [bool]`Errors` - indicate if command encountered errors during its execution (i.e. Access Denied on some file)
 * [string]`LastError` - text of the last encountered error
+
+### Restartable script
+
+Parameter `-OutputFile` specifies where output data is stored on the disk.
+If script is interrupted before finishing, you can restart it without a need to process same folders again.
+Just specify the same `-OutputFile` and script will skip already processed folders.
+
+This is specially useful for long running scripts.
 
 ## Build status
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,9 +2,9 @@
 
 Release notes for PowerShell script **`Get-FolderAge`** by https://github.com/iricigor
 
-## 1.2 - Not released yet
+## 1.2
 
-Date: Wednesday, October 24, 2018 - planned
+Date: Wednesday, October 24, 2018
 
 ### New functionality in 1.2
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -2,6 +2,18 @@
 
 Release notes for PowerShell script **`Get-FolderAge`** by https://github.com/iricigor
 
+## 1.2 - Not released yet
+
+Date: Wednesday, October 24, 2018 - planned
+
+#### Bug fixes in 1.2
+
+- 
+
+### New functionality in 1.2
+
+- Added function alias gfa for Get-FolderAge
+
 ## 1.1
 
 Date: Wednesday, October 17, 2018

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -6,13 +6,17 @@ Release notes for PowerShell script **`Get-FolderAge`** by https://github.com/ir
 
 Date: Wednesday, October 24, 2018 - planned
 
-#### Bug fixes in 1.2
-
-- 
-
 ### New functionality in 1.2
 
+- If interrupted, script can be restarted and it will skip already processed folders
 - Added function alias gfa for Get-FolderAge
+
+#### Bug fixes in 1.2
+
+- Threads not working properly together with OutputFile
+- PowerShell v2 compatibility issues
+
+Full list of resolved issues available [here](https://github.com/iricigor/GetFolderAge/milestone/4?closed=1)
 
 ## 1.1
 


### PR DESCRIPTION
## 1.2

Date: Wednesday, October 24, 2018

### New functionality in 1.2

- If interrupted, script can be restarted and it will skip already processed folders
- Added function alias gfa for Get-FolderAge

#### Bug fixes in 1.2

- Threads not working properly together with OutputFile
- PowerShell v2 compatibility issues

Full list of resolved issues available [here](https://github.com/iricigor/GetFolderAge/milestone/4?closed=1)